### PR TITLE
feat: add optional cleanup activity

### DIFF
--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -97,3 +97,39 @@ Now it's time to perform the actual migration! You'll use the `ado2gh` extension
 - Repository names must be unique in the target GitHub organization: `{{ github_org }}`
 
 </details>
+
+### ⌨️ (_Optional_) Activity: Clean Up Resources
+
+After completing the migration exercise, you may want to clean up the resources that were created during this lab. This step is optional but recommended for keeping your environments tidy.
+
+<details>
+<summary>🧹 Show cleanup steps</summary>
+
+1. **Clean up Azure DevOps project**:
+
+   ```bash
+   cd ado/project
+   terraform apply -destroy -var="ado_token=$ADO_PAT" 
+   ```
+
+   You will be asked to confirm by writing `yes`.
+
+1. **Delete the migrated GitHub repository**:
+
+   - Navigate to the migrated repository on GitHub: https://github.com/{{ github_org }}/{{ target_github_repo_name }}
+   - Go to repository `Settings` tab
+   - Scroll down to the `Danger Zone` and click `Delete this repository`
+   - Follow the prompts to confirm deletion
+
+1. **Revoke GitHub migrator role**:
+
+   ```bash
+   gh ado2gh revoke-migrator-role --actor {{ login }} --actor-type USER --github-org {{ github_org }}
+   ```
+
+1. **Delete Azure DevOps Personal Access Token**:
+
+   - Navigate to your Azure DevOps Organization
+   - Find the token you created for this exercise and delete it
+
+</details>


### PR DESCRIPTION
This pull request adds an optional cleanup activity to the migration lab instructions, helping users tidy up resources created during the exercise. The new section provides detailed, step-by-step guidance for cleaning up both Azure DevOps and GitHub resources.

Documentation improvements:

* Added a new "Clean Up Resources" section to `.github/steps/3-step.md`, including detailed instructions for deleting the Azure DevOps project, removing the migrated GitHub repository, revoking the GitHub migrator role, and deleting the Azure DevOps Personal Access Token.